### PR TITLE
Add WooCommerce Utils plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# woocommerce-utils
+# WooCommerce Utils
+
+WooCommerce Utils is a simple plugin that adds helpful utilities for WooCommerce sites.
+
+Features include:
+
+- Custom **Shipped** order status.
+- An admin page accessible under WooCommerce that describes the plugin.
+
+This repository contains the plugin files for use within WordPress.

--- a/includes/class-wc-utils-admin.php
+++ b/includes/class-wc-utils-admin.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handle admin menu and settings.
+ */
+class WC_Utils_Admin {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+    }
+
+    /**
+     * Register plugin menu.
+     */
+    public function register_menu() {
+        add_submenu_page(
+            'woocommerce',
+            __( 'WooCommerce Utils', 'woocommerce-utils' ),
+            __( 'WC Utils', 'woocommerce-utils' ),
+            'manage_woocommerce',
+            'wc-utils',
+            array( $this, 'render_page' )
+        );
+    }
+
+    /**
+     * Render settings page.
+     */
+    public function render_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'WooCommerce Utils', 'woocommerce-utils' ); ?></h1>
+            <p><?php esc_html_e( 'This plugin adds helpful utilities for WooCommerce.', 'woocommerce-utils' ); ?></p>
+        </div>
+        <?php
+    }
+}

--- a/includes/class-wc-utils-features.php
+++ b/includes/class-wc-utils-features.php
@@ -1,0 +1,45 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Implement various WooCommerce utilities.
+ */
+class WC_Utils_Features {
+
+    public function __construct() {
+        add_filter( 'wc_order_statuses', array( $this, 'register_order_status' ) );
+        add_action( 'init', array( $this, 'add_order_status' ) );
+    }
+
+    /**
+     * Register new order status.
+     */
+    public function add_order_status() {
+        register_post_status( 'wc-shipped', array(
+            'label'                     => 'Shipped',
+            'public'                    => true,
+            'exclude_from_search'       => false,
+            'show_in_admin_all_list'    => true,
+            'show_in_admin_status_list' => true,
+            'label_count'               => _n_noop( 'Shipped <span class="count">(%s)</span>', 'Shipped <span class="count">(%s)</span>', 'woocommerce-utils' )
+        ) );
+    }
+
+    /**
+     * Add to list of WC order statuses.
+     */
+    public function register_order_status( $order_statuses ) {
+        $new_order_statuses = array();
+
+        foreach ( $order_statuses as $key => $status ) {
+            $new_order_statuses[ $key ] = $status;
+            if ( 'wc-processing' === $key ) {
+                $new_order_statuses['wc-shipped'] = _x( 'Shipped', 'WooCommerce order status', 'woocommerce-utils' );
+            }
+        }
+
+        return $new_order_statuses;
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,23 @@
+=== WooCommerce Utils ===
+Contributors: example
+Tags: woocommerce, utilities
+Requires at least: 5.0
+Tested up to: 6.4
+Requires PHP: 7.0
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Adds helpful utilities for WooCommerce, including a custom order status and admin page.
+
+== Description ==
+This plugin provides small utilities for WooCommerce. Currently it adds a custom 'Shipped' order status and an admin page under WooCommerce.
+
+== Installation ==
+1. Upload the plugin files to the `/wp-content/plugins/woocommerce-utils` directory, or install the plugin through the WordPress plugins screen directly.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Navigate to WooCommerce > WC Utils to access the plugin page.
+
+== Changelog ==
+= 1.0.0 =
+* Initial release.

--- a/woocommerce-utils.php
+++ b/woocommerce-utils.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Utils
+ * Description: Provides helpful utilities for WooCommerce.
+ * Version: 1.0.0
+ * Author: Example Author
+ * Text Domain: woocommerce-utils
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Define plugin constants.
+if ( ! defined( 'WC_UTILS_VERSION' ) ) {
+    define( 'WC_UTILS_VERSION', '1.0.0' );
+}
+if ( ! defined( 'WC_UTILS_PATH' ) ) {
+    define( 'WC_UTILS_PATH', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'WC_UTILS_URL' ) ) {
+    define( 'WC_UTILS_URL', plugin_dir_url( __FILE__ ) );
+}
+
+/**
+ * Initialize the plugin.
+ */
+function wc_utils_init() {
+    // Ensure WooCommerce is active.
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        add_action( 'admin_notices', 'wc_utils_missing_wc_notice' );
+        return;
+    }
+
+    // Include required files.
+    require_once WC_UTILS_PATH . 'includes/class-wc-utils-admin.php';
+    require_once WC_UTILS_PATH . 'includes/class-wc-utils-features.php';
+
+    // Initialize classes.
+    new WC_Utils_Admin();
+    new WC_Utils_Features();
+}
+add_action( 'plugins_loaded', 'wc_utils_init' );
+
+/**
+ * Display an admin notice if WooCommerce is not active.
+ */
+function wc_utils_missing_wc_notice() {
+    echo '<div class="notice notice-error"><p>' . esc_html__( 'WooCommerce Utils requires WooCommerce to be active.', 'woocommerce-utils' ) . '</p></div>';
+}
+
+?>


### PR DESCRIPTION
## Summary
- add main plugin file for WooCommerce Utils
- add classes for admin page and custom order status
- document plugin usage and installation

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b2562549c83269390da68b972228b