### PR TITLE
Add GitHub updater and order meta viewer

### DIFF
--- a/includes/class-wc-utils-features.php
+++ b/includes/class-wc-utils-features.php
@@ -11,6 +11,7 @@ class WC_Utils_Features {
     public function __construct() {
         add_filter( 'wc_order_statuses', array( $this, 'register_order_status' ) );
         add_action( 'init', array( $this, 'add_order_status' ) );
+        add_action( 'add_meta_boxes', array( $this, 'add_order_meta_box' ) );
     }
 
     /**
@@ -41,5 +42,39 @@ class WC_Utils_Features {
         }
 
         return $new_order_statuses;
+    }
+
+    /**
+     * Add a meta box showing all order meta values.
+     */
+    public function add_order_meta_box() {
+        add_meta_box(
+            'wc-utils-order-meta',
+            __( 'Order Meta Fields', 'woocommerce-utils' ),
+            array( $this, 'render_order_meta_box' ),
+            'shop_order',
+            'normal',
+            'default'
+        );
+    }
+
+    /**
+     * Render the order meta box.
+     *
+     * @param WP_Post $post Order post object.
+     */
+    public function render_order_meta_box( $post ) {
+        $order = wc_get_order( $post->ID );
+        if ( ! $order ) {
+            return;
+        }
+
+        echo '<table class="widefat striped"><tbody>';
+        foreach ( $order->get_meta_data() as $meta ) {
+            $key   = esc_html( $meta->key );
+            $value = maybe_serialize( $meta->value );
+            echo '<tr><th style="width:200px">' . $key . '</th><td>' . esc_html( $value ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
     }
 }

--- a/includes/class-wc-utils-updater.php
+++ b/includes/class-wc-utils-updater.php
@@ -1,0 +1,133 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Simple GitHub based plugin updater.
+ */
+class WC_Utils_Updater {
+
+    /**
+     * GitHub repository raw URL.
+     *
+     * @var string
+     */
+    private $raw_url;
+
+    /**
+     * GitHub repository zip URL.
+     *
+     * @var string
+     */
+    private $zip_url;
+
+    /**
+     * Plugin file basename.
+     *
+     * @var string
+     */
+    private $plugin_basename;
+
+    /**
+     * Current version.
+     *
+     * @var string
+     */
+    private $version;
+
+    /**
+     * Constructor.
+     */
+    public function __construct( $repo_raw_url, $repo_zip_url, $plugin_basename, $version ) {
+        $this->raw_url        = trailingslashit( $repo_raw_url );
+        $this->zip_url        = $repo_zip_url;
+        $this->plugin_basename = $plugin_basename;
+        $this->version        = $version;
+
+        add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ) );
+        add_filter( 'plugins_api', array( $this, 'plugins_api' ), 10, 3 );
+    }
+
+    /**
+     * Check GitHub for a newer version.
+     *
+     * @param object $transient Update transient.
+     * @return object
+     */
+    public function check_for_update( $transient ) {
+        if ( empty( $transient->checked ) ) {
+            return $transient;
+        }
+
+        $remote = wp_remote_get( $this->raw_url . 'woocommerce-utils.php' );
+
+        if ( is_wp_error( $remote ) ) {
+            return $transient;
+        }
+
+        if ( 200 !== wp_remote_retrieve_response_code( $remote ) ) {
+            return $transient;
+        }
+
+        $body = wp_remote_retrieve_body( $remote );
+
+        if ( ! preg_match( '/^\s*\*\s*Version:\s*(.*)$/mi', $body, $matches ) ) {
+            return $transient;
+        }
+
+        $remote_version = trim( $matches[1] );
+
+        if ( version_compare( $this->version, $remote_version, '>=' ) ) {
+            return $transient;
+        }
+
+        $plugin             = new stdClass();
+        $plugin->slug       = dirname( $this->plugin_basename );
+        $plugin->new_version = $remote_version;
+        $plugin->url        = $this->raw_url;
+        $plugin->package    = $this->zip_url;
+
+        $transient->response[ $this->plugin_basename ] = $plugin;
+
+        return $transient;
+    }
+
+    /**
+     * Provide plugin information for the update screen.
+     *
+     * @param false|object|array $result The result object or array. Default false.
+     * @param string             $action The type of information being requested from the Plugin Installation API.
+     * @param object             $args   Plugin API arguments.
+     * @return object|false
+     */
+    public function plugins_api( $result, $action, $args ) {
+        if ( 'plugin_information' !== $action ) {
+            return $result;
+        }
+
+        if ( empty( $args->slug ) || dirname( $this->plugin_basename ) !== $args->slug ) {
+            return $result;
+        }
+
+        $remote = wp_remote_get( $this->raw_url . 'readme.txt' );
+
+        if ( is_wp_error( $remote ) || 200 !== wp_remote_retrieve_response_code( $remote ) ) {
+            return $result;
+        }
+
+        $readme = wp_remote_retrieve_body( $remote );
+
+        $info = new stdClass();
+        $info->name    = 'WooCommerce Utils';
+        $info->slug    = dirname( $this->plugin_basename );
+        $info->version = $this->version;
+        $info->sections = array(
+            'description' => $readme,
+        );
+        $info->download_link = $this->zip_url;
+
+        return $info;
+    }
+}
+

--- a/woocommerce-utils.php
+++ b/woocommerce-utils.php
@@ -6,6 +6,7 @@
  * Author: Example Author
  * Text Domain: woocommerce-utils
  * Domain Path: /languages
+ * GitHub Plugin URI: https://github.com/example/woocommerce-utils
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,6 +23,12 @@ if ( ! defined( 'WC_UTILS_PATH' ) ) {
 if ( ! defined( 'WC_UTILS_URL' ) ) {
     define( 'WC_UTILS_URL', plugin_dir_url( __FILE__ ) );
 }
+if ( ! defined( 'WC_UTILS_REPO_RAW' ) ) {
+    define( 'WC_UTILS_REPO_RAW', 'https://raw.githubusercontent.com/example/woocommerce-utils/main/' );
+}
+if ( ! defined( 'WC_UTILS_REPO_ZIP' ) ) {
+    define( 'WC_UTILS_REPO_ZIP', 'https://github.com/example/woocommerce-utils/archive/refs/heads/main.zip' );
+}
 
 /**
  * Initialize the plugin.
@@ -36,10 +43,12 @@ function wc_utils_init() {
     // Include required files.
     require_once WC_UTILS_PATH . 'includes/class-wc-utils-admin.php';
     require_once WC_UTILS_PATH . 'includes/class-wc-utils-features.php';
+    require_once WC_UTILS_PATH . 'includes/class-wc-utils-updater.php';
 
     // Initialize classes.
     new WC_Utils_Admin();
     new WC_Utils_Features();
+    new WC_Utils_Updater( WC_UTILS_REPO_RAW, WC_UTILS_REPO_ZIP, plugin_basename( __FILE__ ), WC_UTILS_VERSION );
 }
 add_action( 'plugins_loaded', 'wc_utils_init' );
 


### PR DESCRIPTION
## Summary
- add a simple GitHub-based plugin updater
- show WooCommerce order meta in a meta box

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b27c27e1c8326a6f2d3d90a7a73c9