### PR TITLE
Add GitHub release workflow and update updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Build Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create zip
+        run: |
+          mkdir -p build
+          zip -r build/woocommerce-utils.zip . -x '*.git*' '*.github*' 'build*'
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/woocommerce-utils.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/woocommerce-utils.php
+++ b/woocommerce-utils.php
@@ -23,11 +23,9 @@ if ( ! defined( 'WC_UTILS_PATH' ) ) {
 if ( ! defined( 'WC_UTILS_URL' ) ) {
     define( 'WC_UTILS_URL', plugin_dir_url( __FILE__ ) );
 }
-if ( ! defined( 'WC_UTILS_REPO_RAW' ) ) {
-    define( 'WC_UTILS_REPO_RAW', 'https://raw.githubusercontent.com/web-lifter/woocommerce-utils/main/' );
-}
-if ( ! defined( 'WC_UTILS_REPO_ZIP' ) ) {
-    define( 'WC_UTILS_REPO_ZIP', 'https://github.com/web-lifter/woocommerce-utils/archive/refs/heads/main.zip' );
+// GitHub repository slug used for updates.
+if ( ! defined( 'WC_UTILS_GITHUB_REPO' ) ) {
+    define( 'WC_UTILS_GITHUB_REPO', 'web-lifter/woocommerce-utils' );
 }
 
 /**
@@ -48,7 +46,7 @@ function wc_utils_init() {
     // Initialize classes.
     new WC_Utils_Admin();
     new WC_Utils_Features();
-    new WC_Utils_Updater( WC_UTILS_REPO_RAW, WC_UTILS_REPO_ZIP, plugin_basename( __FILE__ ), WC_UTILS_VERSION );
+    new WC_Utils_Updater( WC_UTILS_GITHUB_REPO, plugin_basename( __FILE__ ), WC_UTILS_VERSION );
 }
 add_action( 'plugins_loaded', 'wc_utils_init' );
 


### PR DESCRIPTION
## Summary
- add workflow to zip the plugin and create releases on tag pushes
- adjust constants for GitHub updater
- refactor updater class to download latest release assets instead of `main` branch

## Testing
- `php -l woocommerce-utils.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686b29a32cf48326bff9671e0bddc6c2